### PR TITLE
Add section for midroll links

### DIFF
--- a/_posts/embed-options.md
+++ b/_posts/embed-options.md
@@ -299,7 +299,7 @@ This example is a bit more involved - it specifies the `pageUrl` and
 The Captions plugin enables the Wistia captions functionality for your player.
 
 If you want to programmatically set the text for the captions of a video, check
-out the [Captions API]({{ '/data-api#captions' | post_url }})
+out the [Captions API]({{ '/data-api#captions' | post_url }}).
 
 Option Name    | Type    | Description
 -----------    | ----    | ----------------------------------------------------------------------------------------------------------------------------
@@ -325,4 +325,73 @@ Note that, for `onloadCollapse` to work, `canCollapse` must also be true.
 
 The iPhone and iPad use a slightly different mechanism to show captions. For the iphone, captions can only be turned on when the video is already playing and it's in landscape mode. For the iPad, captions can only be turned on when the video is in fullscreen mode, though they will continue to show when not in fullscreen.
 
+
+## Midroll Links Plugin
+
+The Midroll Links plugin displays mid-playback links or plaintext notes.
+
+If you want to programmatically set midroll links for a video, check out the [Customizations API]({{ '/data-api#customizations' | post_url }}).
+
+Plugin Option | Type    | Description
+------------- | ------- | -----------
+manualModeOn  | boolean | In manual mode, `links` are ignored and a script can take full control over what links to display, and when. Defaults to `false`.
+links         | array   | An array of objects specifying the links to display at what times. See below.
+
+Link Option | Type    | Description
+----------- | ------- | -----------
+time        | int     | The time this midroll link appears, in seconds. *Required.*
+duration    | int     | The amount of time this midroll link stays visible, in seconds. *Required.*
+text        | string  | The plain text content of this midroll link. HTML is not allowed. *Required.*
+url         | string  | The url to link to. If `null` or `""`, `text` will be shown as plain text instead of as a link. *Optional.*
+
+### Using the Midroll Links plugin
+
+{% codeblock midroll-links-params.html %}
+<script>
+  wistiaEmbed = Wistia.embed("abcde12345", {
+    plugin: {
+      "midrollLink-v1": {
+        links: [
+          {
+            time: 3,
+            duration: 5,
+            text: "Click me!"
+            url: "http://wistia.com"
+          }
+        ]
+      }
+    }
+  });
+</script>
+{% endcodeblock %}
+
+#### Manual mode
+
+In manual mode, your own script can take control of showing links. In this case, you can access the plugin at `wistiaEmbed.plugin['midrollLink-v1']`, and use the methods `forceShowLink` and `forceHideLink` at will. The `forceShowLink` method accepts an object with the same link options as above, but ignores `time` and `duration`.
+
+{% codeblock midroll-links-manual.html %}
+<script>
+  wistiaEmbed = Wistia.embed("abcde12345", {
+    plugin: {
+      "midrollLink-v1": {
+        manualModeOn: true
+      }
+    }
+  });
+
+  var myCustomLink = {text: 'Click here!', url: 'https://wistia.com'};
+  var isShowingLink = false;
+
+  wistiaEmbed.bind('timechange', function(timeInSeconds) {
+    if (timeInSeconds > 10 && timeInSeconds < 20 && !isShowingLink) {
+      wistiaEmbed.plugin['midrollLink-v1'].forceShowLink(myCustomLink);
+      isShowingLink = true;
+    }
+    else if (isShowingLink) {
+      wistiaEmbed.plugin['midrollLink-v1'].forceHideLink();
+      isShowingLink = false;
+    }
+  });
+</script>
+{% endcodeblock %}
 


### PR DESCRIPTION
Just like it says in the title. :candy:

I added a section on using it in a "manual mode", which uses the plugin for its API instead of for showing predefined links. I thought it might be useful for our customers who have their own developers and who might scheme up some more advanced custom use case than most other customers (and maybe save our champs from some tough questions later). Suggestions to move, fix up, simplify, or remove that section are welcome.