### PR TITLE
Updating search to use plus signs instead of underscores for search

### DIFF
--- a/_coffeescript/search.coffee
+++ b/_coffeescript/search.coffee
@@ -22,7 +22,7 @@ class Search
     $.getJSON "#{basepath}/search/#{query}?format=json&callback=?", callback
 
   stringify: (str) ->
-    str.replace(/_/g, ' ')
+    str.replace(/\+/g, ' ')
 
   noResultsStr: (query) ->
     """

--- a/_coffeescript/search_text.coffee
+++ b/_coffeescript/search_text.coffee
@@ -1,5 +1,5 @@
 performSearch = () ->
-  enteredQuery = $('#searchField').val().replace(/[ ]/g, '_')
+  enteredQuery = $('#searchField').val().replace(/[ ]/g, '+')
   window.location.replace "#{basepath}/search?query=#{enteredQuery}"
 
 $('#search button').on 'click', ->

--- a/the_app.rb
+++ b/the_app.rb
@@ -61,7 +61,7 @@ class TheApp < Sinatra::Base
   get '/search/:q' do
     text = params[:q]
 
-    text.gsub!('_', ' ')
+    text.gsub!('+', ' ')
 
     query = {
       query: {


### PR DESCRIPTION
When looking into how to setup custom searches in Alfred, there are two options for translating spaces into a URL-friendly manner: UTF-8 and plus signs. We were using underscores, which seems to be a relatively arbitrary choice. To increase compatibility with Alfred and make it a bit more normalized with common ways that web searches work in terms of URL. I've made some changes to that in the docs.

With @MaxPower15's help, I found a few spots that we referenced the old underscore way.

1. search_text.coffee is where we make the real magic happen
2. search.coffee has some fun stringify magic to mirror the way that search_text works
3. more of the same for the_app.rb

When running rake build, some other files changed as well. The changes, presumably, will happen automatically upon building during the deploy:

	modified:   index.html
	modified:   javascripts/search.js
	modified:   javascripts/search_text.js
	modified:   stylesheets/screen.css

@jeffvincent @emb78 Wanna get some :eyes: on this one? Yay/nay?