### PR TITLE
Add piece to tell folks how to make an event available in Marketo

### DIFF
--- a/_posts/marketo.md
+++ b/_posts/marketo.md
@@ -58,9 +58,13 @@ section of the Customize panel.
 
 ## Setting Up Marketing Automation Based on Video Viewing Data
 
-Wouldn't it be cool if when a person watches at least 50% of a certain video on your website, you could automatically send them an email about that product a few days later? Or if a person watched 75% of a video, you could have a salesperson get notified to follow up?
+Wouldn't it be cool if when a person watches at least 50% of a certain video on your website, you could automatically send them an email about that product a few days later? Or if a person entered their email address into Turnstile, you could have a salesperson get notified to follow up?
 
-"Why yes, yes that would be quite cool indeed," you say? Phew! Good thing we built this integration. Here's how to do stuff like that:
+"Why yes, yes that would be quite cool indeed," you say? Phew! Good thing we built this integration.
+
+{{ "Before you can trigger automation in Marketo based on a Wistia video event on your website, that event will need to occur at least once. So before anything else, go onto your website and do the thing you want to use as a trigger in the embedded video (like watch 50% of the video, or click an Annotation Link) – just like regular visitor to your website would. Then Marketo will let you select it as a trigger." | note }}
+
+Have you read the super important note above and done the thing you'd like to use as a trigger? Alrighty then, carry on! Here's how to set the automation up:
 
 1. Head to the Marketing Activities section in your Marketo account.
 2. Create a new Smart Campaign. Choose a folder, and give the campaign a name. A description too, if you'd like.
@@ -69,7 +73,6 @@ Wouldn't it be cool if when a person watches at least 50% of a certain video on 
   {% post_image hashed_id: 'b13848f78c7bdffb0bb590caf6e8254efbdd927b', class: 'center' %}
 5. Now it's time to define the specific video event trigger. If you wanted to run automation when a person watches 75% of a video called "<a href="//fast.wistia.net/embed/iframe/nto1tvx7mz?popover=true" class="wistia-popover[height=360,playerColor=1789ce,width=640]">Making French Toast at Wistia</a>", you'd tell Marketo to set the trigger to _Web Page --> is --> Wistia Video: "Making French Toast at Wistia" 75% Watched_.
   {% post_image hashed_id: 'd64c0b0cfa51632198e2380c43ec6faef28f0371', class: 'center' %}
-  Don't see the event that you want to use as a trigger? That's probably because Wistia has never reported that event to Marketo before. To fix that, go onto your website and do the thing you want to use as a trigger (like watch 75% of your video, or click an Annotation Link) just like regular visitor to your website would. Then Marketo will let you use it as a trigger.
 6. Once you've picked the right event for the right video, move onto the Flow step. That's all Marketo's domain, so **[check out the Marketo documentation](https://docs.marketo.com/display/public/DOCS/Add+a+Flow+Step+to+a+Smart+Campaign)** for details.
 
 There are a bunch of other things you can automate too, like:

--- a/_posts/marketo.md
+++ b/_posts/marketo.md
@@ -69,6 +69,7 @@ Wouldn't it be cool if when a person watches at least 50% of a certain video on 
   {% post_image hashed_id: 'b13848f78c7bdffb0bb590caf6e8254efbdd927b', class: 'center' %}
 5. Now it's time to define the specific video event trigger. If you wanted to run automation when a person watches 75% of a video called "<a href="//fast.wistia.net/embed/iframe/nto1tvx7mz?popover=true" class="wistia-popover[height=360,playerColor=1789ce,width=640]">Making French Toast at Wistia</a>", you'd tell Marketo to set the trigger to _Web Page --> is --> Wistia Video: "Making French Toast at Wistia" 75% Watched_.
   {% post_image hashed_id: 'd64c0b0cfa51632198e2380c43ec6faef28f0371', class: 'center' %}
+  Don't see the event that you want to use as a trigger? That's probably because Wistia has never reported that event to Marketo before. To fix that, go onto your website and do the thing you want to use as a trigger (like watch 75% of your video, or click an Annotation Link) just like regular visitor to your website would. Then Marketo will let you use it as a trigger.
 6. Once you've picked the right event for the right video, move onto the Flow step. That's all Marketo's domain, so **[check out the Marketo documentation](https://docs.marketo.com/display/public/DOCS/Add+a+Flow+Step+to+a+Smart+Campaign)** for details.
 
 There are a bunch of other things you can automate too, like:


### PR DESCRIPTION
Wistia video events will only be available within Marketo after the first time Wistia reports such events to Marketo. This PR adds that aspect to the automation process described in the Marketo doc.

@emilyscoleman your feedback on this part of the Marketo guide would be much appreciated! The process is weird and complex, and I fear that this list format is a bit messy. What do you think? Can you think of a better way to guide people through this flow?