### PR TITLE
ruby-example-update

### DIFF
--- a/_posts/working-with-images.md
+++ b/_posts/working-with-images.md
@@ -116,21 +116,21 @@ ampersand.
 ## Using the Wistia Data API Ruby Gem
 
 When making a request against the [Data API]({{ '/data-api' | post_url }}), the
-media assets includes a still image (the thumbnail!).
+media assets includes an array of assets.
 
 {% codeblock ruby_gem.rb %}
 m = Wistia::Media.first
-m.assets.select{ |a| a.attributes["type"] == "StillImageFile" }.first
+m.assets.select{ |a| a.attributes["type"] == "OriginalFile" }.first
 => #<Wistia::Media::Asset:0x007fa67caced68 @attributes={
     "url"=>"http://embed.wistia.com/deliveries/b300126144f62ba2942ec4a4f29e949a47e16f12.bin",
-    "width"=>640, "height"=>360, "fileSize"=>48442, "contentType"=>"image/jpeg", 
-    "type"=>"StillImageFile"
+    "width"=>640, "height"=>360, "fileSize"=>48442, "contentType"=>"video/mp4", 
+    "type"=>"OriginalFile"
   }, @prefix_options={}, @persisted=false>
 url = _.url
 => "http://embed.wistia.com/deliveries/b300126144f62ba2942ec4a4f29e949a47e16f12.bin"
 {% endcodeblock %}
 
-You can then apply the same geometry strings to the thumbnail URL.
+You can then apply the same geometry strings to this URL.
 You'll also have to change that `.bin` extension to `.jpg`.
 
 {% codeblock ruby_gem.rb %}


### PR DESCRIPTION
I propose using a video asset instead of the still image asset so you can use the `video_still_time` attribute with images.

If you choose the still image asset, you cannot use the video_still_time attribute and there is no error telling you why, you just get a 400 bad request error. If you use the `OriginalFile` asset url, then you can use the video_still_time that is mentioned at [http://wistia.com/doc/extracting-thumbnails](http://wistia.com/doc/extracting-thumbnails).

I used the example for the Wistia Data API Ruby Gem on this page, then I had to spend some time debugging to figure out why I couldn't use video_still_time with my url.