### PR TITLE
Update Index for New Pages and Categories

### DIFF
--- a/_posts/customizing-your-video.md
+++ b/_posts/customizing-your-video.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title: Customize
+title: Customizing Your Video
 description: Drive more interaction and better engagement with your content using Wistia video customization features.
-category: Video
+category: Customize
 post_intro: <p>Your video content is truly powerful - and Wistia customization can ensure engagement with your audience, which drives business for you.</p><p>This article will cover the customization options for your video, and how to make them work for you.</p><p>Once you customize your video, you can also choose to <a href="http://wistia.com/doc/embedding">embed it</a> with your customizations.</p>
 ---
 

--- a/_posts/email-marketing.md
+++ b/_posts/email-marketing.md
@@ -1,7 +1,7 @@
 ---
 title: Email Marketing and Wistia
 layout: post
-category: Embed & Share
+category: embed and share
 description: Learn how we integrate with some of the top email marketing platforms to make your campaigns even more powerful in no time.
 post_intro:
   <p>Email marketing campaigns are great for engaging your prospects with timely messages.  When done right, they can be an excellent driver of business value.</p><p>Adding video to the mix is an effective way to increase click-through rates and maximize engagement with your message.  Wistia makes it easy to integrate video with your email-marketing campaigns, as well as measure the results down to the individual viewer, second-by-second.</p><p>After this tutorial you will be able to integrate video into your email marketing campaigns, and understand which recipients are engaged with your message.</p><img class="center intro_image post_image" src="http://embed.wistia.com/deliveries/97291f1a3b3898ec951a80296504441a9b3d0ce0.png" width="600" alt="email_heatmap" />

--- a/_posts/embedding.md
+++ b/_posts/embedding.md
@@ -1,7 +1,7 @@
 ---
 title: Embedding Video on Your Website
 layout: post
-category: Embed & Share
+category: embed and share
 description: Want to add video to your website (embedding) but don't know where to start? Here's a quick guide to get you off the ground!
 post_intro:
   <p>Putting video on your website is the best way to get your message across.

--- a/_posts/google-analytics.md
+++ b/_posts/google-analytics.md
@@ -2,7 +2,7 @@
 title: Google Analytics
 layout: post
 category: Integrations
-post_intro: At Wistia, we love analytics.  While ours are pretty sweet, there are lots of tools out there, like <a href="http://google.com/analytics" title="google analytics">Google Analytics</a>. While Wistia's analytics give you more in-depth information on video plays, putting basic video metrics in Google Analytics can give you a better picture of how they tie together with your website's metrics.</p><p>This guide is here to help you get started integrating Wistia video tracking with your Google Analytics account.</p>
+post_intro: <p>At Wistia, we love analytics.  While ours are pretty sweet, there are lots of tools out there, like <a href="http://google.com/analytics" title="google analytics">Google Analytics</a>. While Wistia's analytics give you more in-depth information on video plays, putting basic video metrics in Google Analytics can give you a better picture of how they tie together with your website's metrics.</p><p>This guide is here to help you get started integrating Wistia video tracking with your Google Analytics account.</p>
 description: Learn how to use Wistia and Google Analytics together to track video plays.
 footer: 'for_intermediates'
 

--- a/_posts/integrations.md
+++ b/_posts/integrations.md
@@ -3,6 +3,7 @@ title: Integrations
 layout: post
 description: Wistia plays well with lots of 3rd party services. See some of the best, and how to use them, in this article.
 post_intro: <p>As we update our embedding processes and APIs, Wistia will get better and better at integrating with other top-notch services. On this doc page, we'll do our best to keep track of places where Wistia works out-of-the-box for embedding, and also where deeper integrations have been built out by our awesome friends.</p><p>If you currently use a service that you think rocks, and would work well with Wistia, submit your request in <a href="https://docs.google.com/a/wistia.com/forms/d/1x2Z2KUdxXKhPYpfzfQJLVq7upAnhryBWZt2Y4IUPiTs/viewform" target="_blank">this form</a>.</p>
+category: integrations
 ---
 
 ## Pardot
@@ -45,7 +46,7 @@ On the Zapbook page for Wistia, Zapier has handily included a bunch of sample za
 
 {% post_image hashed_id: '97d57d4890140c3e6f529e7e58fe7b7d3610d9b5', width: 200, class: 'integration_logo' %}
 
-The [Media:Wistia Drupal Module](http://drupal.org/project/media_wistia) makes embedding both videos and playlists easy using either Wistia URLs or embed codes. 
+The [Media:Wistia Drupal Module](http://drupal.org/project/media_wistia) makes embedding both videos and playlists easy using either Wistia URLs or embed codes.
 
 This was updated by dev-god [Travis Carden](http://drupal.org/user/236758), thanks Travis!
 
@@ -85,7 +86,7 @@ We love seeing Wistia videos out there in the wild. This is an incomplete list o
 * Google Sites
 * Lexblog
 * Medium
-* MotoCMS 
+* MotoCMS
 * Portfoliobox
 * [Sharepoint](http://office.microsoft.com/en-us/office365-sharepoint-online-enterprise-help/embed-video-on-a-public-website-page-HA102828149.aspx)
 * [Shopify](http://docs.shopify.com/manual/configuration/store-customization/embed-video)

--- a/_posts/playlists.md
+++ b/_posts/playlists.md
@@ -1,7 +1,7 @@
 ---
 title: Wistia Video Playlists
 layout: post
-category: Embed & Share
+category: embed and share
 description: Video playlists are a great way to embed multiple videos on your website through a single embed.  Playlists allow you to update content in your playlist without messing with embed codes (even after embedding!).
 post_intro: <p>Video playlists are a great way to embed multiple videos on your website through a single embed.  Playlists allow you to update content in your playlist without messing with embed codes (even after embedding!).</p><p>They take up less real estate than separate video embeds, while being easier to navigate.  In short, they are a super cool and useful embed type.</p>
 ---

--- a/_posts/security.md
+++ b/_posts/security.md
@@ -2,7 +2,7 @@
 title: Wistia Video Security
 layout: post
 description: Wistia provides multiple levels of security for your videos. Learn more here!
-category: Account
+category: Getting Started
 ---
 
 

--- a/_posts/social-sharing.md
+++ b/_posts/social-sharing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Wistia and Social Sharing
-category: Embed & Share
+category: embed and share
 description: Want to get social with your Wistia videos? We make it simple to share and track your videos on your favorite social media sites, such as Facebook and Twitter.
 post_intro: <p>Social Media can drive some serious ROI if done right.  Vehicles like Facebook and Twitter can be used to spread a business message effectively, especially if delivered in an easy to consume and share way.  The best way to do that is with video - it's perfect for social media attention spans, so it tends to 'travel' better than blocks of text.</p><p>Now that you've got your video uploaded to Wistia, how do you share it and track the performance on Social Media sites?  This tutorial will help.  The two services we're focused on here are Facebook and Twitter.</p>
 ---

--- a/_posts/updating-your-embeds.md
+++ b/_posts/updating-your-embeds.md
@@ -3,7 +3,7 @@ title: Keeping Your Embeds Up To Date
 layout: post
 description: Are your embedded Wistia videos looking a little dusty? Using an old version of the Wistia Javascript library? Here's how to keep your Wistia embeds fresh with the latest & greatest Wistia player technology.
 post_intro: Are your embedded Wistia videos looking a little dusty? Using an old version of the Wistia Javascript library? Here's how to keep your Wistia embeds fresh with the latest & greatest Wistia player technology.
-category: Embed & Share
+category: embed and share
 ---
 
 ## Updating embeds created before 2012

--- a/_posts/video-seo.md
+++ b/_posts/video-seo.md
@@ -1,7 +1,7 @@
 ---
 title: Video SEO
 layout: post
-category: Embed & Share
+category: embed and share
 description: Video SEO is a powerful tool for your business, and here at Wistia we've got it fully covered. Learn the steps to get that set up in your account here.
 post_intro: <p>Video SEO is the practice of providing the metadata (or "information") for your content to search engines to improve the richness of search results (i.e. "rich snippets") and ultimately drive more web visitors.</p><p>Wistia provides both recommended approaches to Video SEO - using what's called a "video sitemap", and also utilizing specific markup in the on-page embed code. As a part of your marketing arsenal, following the proper metadata and markup conventions improves your video asset's presence on search engines.</p>
 ---

--- a/_sass/_index_page.sass
+++ b/_sass/_index_page.sass
@@ -83,7 +83,10 @@
     &.developers
       width: 50%
   .secondRow
-    height: 296px
+    height: 270px
+    margin-top: 6px
+  .thirdRow
+    height: 270px
     margin-top: 6px
   .left
     width: 25%

--- a/_static_pages/index.haml
+++ b/_static_pages/index.haml
@@ -14,9 +14,9 @@ no_nav: true
         %h2 Greatest Hits
         %ul
           %li
-            %a{ href: "{{ '/plans-comparison' | post_url }}" } Comparing Wistia Plans
+            %a{ href: "{{ '/account-setup' | post_url }}" } Account Set Up
           %li
-            %a{ href: "{{ '/account-setup' | post_url }}" } Account Setup
+            %a{ href: "{{ '/export-settings' | post_url }}" } Optimal Export Settings
           %li
             %a{ href: "{{ '/customizing-your-video' | post_url }}" } Customizing Your Video
           %li
@@ -32,82 +32,85 @@ no_nav: true
     .section
       #gettingSetUp.column.left.secondRow
         %h2
-          %a{ href: "{{ 'getting-set-up' | category_url }}" }
-            Getting Set Up
+          %a{ href: "{{ 'getting-started' | category_url }}" }
+            Getting Started
         %ul
-          %li
-            %a{ href: "{{ '/plans-comparison' | post_url }}" }
-              Plans & Pricing Details
-          %li
-            %a{ href: "{{ '/account-setup' | post_url }}" }
-              Account Setup
-          %li
-            %a{ href: "{{ '/viewer-rec' | post_url }}" }
-              Viewer Requirements
           %li
             %a{ href: "{{ '/export-settings' | post_url }}" }
               Optimal Export Settings
           %li
             %a{ href: "{{ '/exporting-guide' | post_url }}" }
-              Exporting From Video Editors
+              Exporting from Video Editors
+          %li
+            %a{ href: "{{ '/upload-video' | post_url }}" }
+              Uploading
+          %li
+            %a{ href: "{{ '/viewer-requirements' | post_url }}" }
+              Viewer Requirements
           %li
             %a{ href: "{{ '/security' | post_url }}" }
               Wistia Video Security
-        %a.viewAll{ href: "{{ 'getting-set-up' | category_url }}" }
-          View All 7
+        %a.viewAll{ href: "{{ 'getting-started' | category_url }}" }
+          View All 6
       #embedding.column.middle.secondRow
         %h2
-          %a{ href: "{{ 'embedding' | category_url }}" }
-            Customize & Embed
+          %a{ href: "{{ 'account' | category_url }}" }
+            Account
+        %ul
+          %li
+            %a{ href: "{{ '/account-setup' | post_url }}" }
+              Getting Set Up
+          %li
+            %a{ href: "{{ '/bandwidth' | post_url }}" }
+              Bandwidth
+          %li
+            %a{ href: "{{ '/media' | post_url }}" }
+              Media in Wistia
+          %li
+            %a{ href: "{{ '/projects' | post_url }}" }
+              All About Projects
+          %li
+            %a{ href: "{{ '/permissions' | post_url }}" }
+              User Permissions
+        %a.viewAll{ href: "{{ 'account' | category_url }}" }
+          View All 8
+      #privateSharing.column.right.secondRow
+        %h2
+          %a{ href: "{{ 'customize' | category_url }}" }
+            Customize
         %ul
           %li
             %a{ href: "{{ '/customizing-your-video' | post_url }}" }
-              Customizing Your Video
+              Customizing your Video
+          %li
+            %a{ href: "{{ '/turnstile' | post_url }}" }
+              Turnstile Email Capture
+          %li
+            %a{ href: "{{ '/replace-video' | post_url }}" }
+              Replace Video
+          %li
+            %a{ href: "{{ '/captions' | post_url }}" }
+              Captions
+    .section
+      #analytics.column.left.thirdRow
+        %h2
+          %a{ href: "{{ 'embed-and-share' | category_url }}" } Embed & Share
+        %ul
           %li
             %a{ href: "{{ '/embedding' | post_url }}" }
-              Embedding Video on Your Website
+              Embedding
           %li
-            %a{ href: "{{ '/playlists' | post_url }}" }
-              Video Playlists
+            %a{ href: "{{ '/video-seo | post_url }}" }
+              Video SEO
           %li
             %a{ href: "{{ '/social-sharing' | post_url }}" }
               Social Sharing
           %li
-            %a{ href: "{{ '/captions' | post_url }}" }
-              Captions
-        %a.viewAll{ href: "{{ 'embedding' | category_url }}" }
-          View All 6
-      #privateSharing.column.right.secondRow
-        %h2
-          %a{ href: "{{ 'private-sharing' | category_url }}" }
-            Private Sharing
-        %ul
+            %a{ href: "{{ '/email-marketing' | post_url }}" }
+              Email Marketing and Wistia
           %li
-            %a{ href: "{{ '/private-sharing' | post_url }}" }
-              Sharing Video Privately
-          %li
-            %a{ href: "{{ '/contacts' | post_url }}" }
-              Contact Management
-          %li
-            %a{ href: "{{ '/permissions' | post_url }}" }
-              Permission Types in Wistia
-          %li
-            %a{ href: "{{ '/alerts' | post_url }}" }
-              Tracking Alerts
-    .section
-      #analytics.column.left.thirdRow
-        %h2
-          %a{ href: "{{ 'analytics' | category_url }}" } Analytics
-        %ul
-          %li
-            %a{ href: "{{ '/embedded-video-analytics' | post_url }}" }
-              Analytics for Public Video
-          %li
-            %a{ href: "{{ '/private-analytics' | post_url }}" }
-              Analytics for Private Video
-          %li
-            %a{ href: "{{ '/identity-tagging' | post_url }}" }
-              Identity Tagging
+            %a{ href: "{{ '/playlists' | post_url }}" }
+              Playlists
       #integrations.column.middle.thirdRow
         %h2
           %a{ href: "{{ 'integrations' | category_url }}" }
@@ -123,28 +126,30 @@ no_nav: true
             %a{ href: "{{ '/mailchimp' | post_url }}" }
               MailChimp
           %li
-            %a{ href: "{{ '/pardot' | post_url }}" }
-              Pardot
-          %li
             %a{ href: "{{ '/wordpress' | post_url }}" }
               WordPress
           %li
             %a{ href: "{{ '/google-analytics' | post_url }}" }
               Google Analytics
+          %a.viewAll{ href: "{{ 'integrations' | category_url }}" }
+            View All 13
       #publicSharing.column.right.thirdRow
         %h2
-          %a{ href: "{{ 'public-sharing' | category_url }}" }
-            Public Sharing
+          %a{ href: "{{ 'stats' | category_url }}" }
+            Stats
         %ul
           %li
-            %a{ href: "{{ '/email-marketing' | post_url }}" }
-              Email Marketing
+            %a{ href: "{{ '/embedded-video-analytics' | post_url }}" }
+              Analytics Overview
           %li
-            %a{ href: "{{ '/video-seo' | post_url }}" }
-              Video SEO
+            %a{ href: "{{ '/audience-engagement-graph' | post_url }}" }
+              Engagement Graphs
           %li
-            %a{ href: "{{ '/replaceable-video' | post_url }}" }
-              Replaceable Video
+            %a{ href: "{{ '/private-analytics' | post_url }}" }
+              Private Analytics
+          %li
+            %a{ href: "{{ '/identity-tagging' | post_url }}" }
+              Identity Tagging
     .section.last
       #developers.column.left.thirdRow.developers
         %h2

--- a/_static_pages/index.haml
+++ b/_static_pages/index.haml
@@ -131,8 +131,8 @@ no_nav: true
           %li
             %a{ href: "{{ '/google-analytics' | post_url }}" }
               Google Analytics
-          %a.viewAll{ href: "{{ 'integrations' | category_url }}" }
-            View All 13
+        %a.viewAll{ href: "{{ 'integrations' | category_url }}" }
+          View All 13
       #publicSharing.column.right.thirdRow
         %h2
           %a{ href: "{{ 'stats' | category_url }}" }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ no_nav: true
         <h2>Greatest Hits</h2>
         <ul>
           <li>
-            <a href="{{ '/account-setup' | post_url }}">Account Setup</a>
+            <a href="{{ '/account-setup' | post_url }}">Account Set Up</a>
           </li>
           <li>
             <a href="{{ '/export-settings' | post_url }}">Optimal Export Settings</a>
@@ -32,17 +32,14 @@ no_nav: true
       </div>
       <div class='columnBig firstRow homepage-search' id='search'>
         <h2>Search</h2>
-        <form>
-          <input class='st-default-search-input' id='searchField' placeholder='What are you looking for?' type='text' />
-          <button></button>
-        </form>
+        <input class='st-default-search-input' id='searchField' placeholder='What are you looking for?' type='text' />
       </div>
     </div>
     <div class='section'>
       {% include wistia-basics-thumbnails.html %}
     </div>
     <div class='section'>
-      <div class='column left secondRow' id='gettingStarted'>
+      <div class='column left secondRow' id='gettingSetUp'>
         <h2>
           <a href="{{ 'getting-started' | category_url }}">
             Getting Started
@@ -56,7 +53,7 @@ no_nav: true
           </li>
           <li>
             <a href="{{ '/exporting-guide' | post_url }}">
-              Exporting From Video Editors
+              Exporting from Video Editors
             </a>
           </li>
           <li>
@@ -79,7 +76,7 @@ no_nav: true
           View All 6
         </a>
       </div>
-      <div class='column middle secondRow' id='account'>
+      <div class='column middle secondRow' id='embedding'>
         <h2>
           <a href="{{ 'account' | category_url }}">
             Account
@@ -108,7 +105,7 @@ no_nav: true
           </li>
           <li>
             <a href="{{ '/permissions' | post_url }}">
-              Permissions
+              User Permissions
             </a>
           </li>
         </ul>
@@ -116,16 +113,16 @@ no_nav: true
           View All 8
         </a>
       </div>
-      <div class='column right secondRow' id='customize'>
+      <div class='column right secondRow' id='privateSharing'>
         <h2>
-          <a href="{{ 'Customize' | category_url }}">
+          <a href="{{ 'customize' | category_url }}">
             Customize
           </a>
         </h2>
         <ul>
           <li>
             <a href="{{ '/customizing-your-video' | post_url }}">
-              Customize Your Video
+              Customizing your Video
             </a>
           </li>
           <li>
@@ -147,7 +144,7 @@ no_nav: true
       </div>
     </div>
     <div class='section'>
-      <div class='column left thirdRow' id='embedShare'>
+      <div class='column left thirdRow' id='analytics'>
         <h2>
           <a href="{{ 'embed-and-share' | category_url }}">Embed & Share</a>
         </h2>
@@ -158,7 +155,7 @@ no_nav: true
             </a>
           </li>
           <li>
-            <a href="{{ '/video-seo' | post_url }}">
+            <a href="{{ '/video-seo | post_url }}">
               Video SEO
             </a>
           </li>
@@ -211,12 +208,12 @@ no_nav: true
               Google Analytics
             </a>
           </li>
+          <a class='viewAll' href="{{ 'integrations' | category_url }}">
+            View All 13
+          </a>
         </ul>
-        <a class='viewAll' href="{{ 'integrations' | category_url }}">
-          View All 13
-        </a>
       </div>
-      <div class='column right thirdRow' id='stats'>
+      <div class='column right thirdRow' id='publicSharing'>
         <h2>
           <a href="{{ 'stats' | category_url }}">
             Stats
@@ -310,7 +307,7 @@ no_nav: true
 <script type='text/javascript'>
   //<![CDATA[
     var iOS = ( navigator.userAgent.match(/(iPad|iPhone|iPod)/i) ? true : false );
-
+    
     if (!iOS) {
       $('.post_list li').each( function() {
         var $this = $(this),

--- a/index.html
+++ b/index.html
@@ -208,10 +208,10 @@ no_nav: true
               Google Analytics
             </a>
           </li>
-          <a class='viewAll' href="{{ 'integrations' | category_url }}">
-            View All 13
-          </a>
         </ul>
+        <a class='viewAll' href="{{ 'integrations' | category_url }}">
+          View All 13
+        </a>
       </div>
       <div class='column right thirdRow' id='publicSharing'>
         <h2>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@ no_nav: true
         <h2>Greatest Hits</h2>
         <ul>
           <li>
-            <a href="{{ '/plans-comparison' | post_url }}">Comparing Wistia Plans</a>
+            <a href="{{ '/account-setup' | post_url }}">Account Setup</a>
           </li>
           <li>
-            <a href="{{ '/account-setup' | post_url }}">Account Setup</a>
+            <a href="{{ '/export-settings' | post_url }}">Optimal Export Settings</a>
           </li>
           <li>
             <a href="{{ '/customizing-your-video' | post_url }}">Customizing Your Video</a>
@@ -42,28 +42,13 @@ no_nav: true
       {% include wistia-basics-thumbnails.html %}
     </div>
     <div class='section'>
-      <div class='column left secondRow' id='gettingSetUp'>
+      <div class='column left secondRow' id='gettingStarted'>
         <h2>
-          <a href="{{ 'getting-set-up' | category_url }}">
-            Getting Set Up
+          <a href="{{ 'getting-started' | category_url }}">
+            Getting Started
           </a>
         </h2>
         <ul>
-          <li>
-            <a href="{{ '/plans-comparison' | post_url }}">
-              Plans & Pricing Details
-            </a>
-          </li>
-          <li>
-            <a href="{{ '/account-setup' | post_url }}">
-              Account Setup
-            </a>
-          </li>
-          <li>
-            <a href="{{ '/viewer-rec' | post_url }}">
-              Viewer Requirements
-            </a>
-          </li>
           <li>
             <a href="{{ '/export-settings' | post_url }}">
               Optimal Export Settings
@@ -75,40 +60,82 @@ no_nav: true
             </a>
           </li>
           <li>
+            <a href="{{ '/upload-video' | post_url }}">
+              Uploading
+            </a>
+          </li>
+          <li>
+            <a href="{{ '/viewer-requirements' | post_url }}">
+              Viewer Requirements
+            </a>
+          </li>
+          <li>
             <a href="{{ '/security' | post_url }}">
               Wistia Video Security
             </a>
           </li>
         </ul>
-        <a class='viewAll' href="{{ 'getting-set-up' | category_url }}">
-          View All 7
+        <a class='viewAll' href="{{ 'getting-started' | category_url }}">
+          View All 6
         </a>
       </div>
-      <div class='column middle secondRow' id='embedding'>
+      <div class='column middle secondRow' id='account'>
         <h2>
-          <a href="{{ 'embedding' | category_url }}">
-            Customize & Embed
+          <a href="{{ 'account' | category_url }}">
+            Account
+          </a>
+        </h2>
+        <ul>
+          <li>
+            <a href="{{ '/account-setup' | post_url }}">
+              Getting Set Up
+            </a>
+          </li>
+          <li>
+            <a href="{{ '/bandwidth' | post_url }}">
+              Bandwidth
+            </a>
+          </li>
+          <li>
+            <a href="{{ '/media' | post_url }}">
+              Media in Wistia
+            </a>
+          </li>
+          <li>
+            <a href="{{ '/projects' | post_url }}">
+              All About Projects
+            </a>
+          </li>
+          <li>
+            <a href="{{ '/permissions' | post_url }}">
+              Permissions
+            </a>
+          </li>
+        </ul>
+        <a class='viewAll' href="{{ 'account' | category_url }}">
+          View All 8
+        </a>
+      </div>
+      <div class='column right secondRow' id='customize'>
+        <h2>
+          <a href="{{ 'Customize' | category_url }}">
+            Customize
           </a>
         </h2>
         <ul>
           <li>
             <a href="{{ '/customizing-your-video' | post_url }}">
-              Customizing Your Video
+              Customize Your Video
             </a>
           </li>
           <li>
-            <a href="{{ '/embedding' | post_url }}">
-              Embedding Video on Your Website
+            <a href="{{ '/turnstile' | post_url }}">
+              Turnstile Email Capture
             </a>
           </li>
           <li>
-            <a href="{{ '/playlists' | post_url }}">
-              Video Playlists
-            </a>
-          </li>
-          <li>
-            <a href="{{ '/social-sharing' | post_url }}">
-              Social Sharing
+            <a href="{{ '/replace-video' | post_url }}">
+              Replace Video
             </a>
           </li>
           <li>
@@ -117,59 +144,37 @@ no_nav: true
             </a>
           </li>
         </ul>
-        <a class='viewAll' href="{{ 'embedding' | category_url }}">
-          View All 6
-        </a>
-      </div>
-      <div class='column right secondRow' id='privateSharing'>
-        <h2>
-          <a href="{{ 'private-sharing' | category_url }}">
-            Private Sharing
-          </a>
-        </h2>
-        <ul>
-          <li>
-            <a href="{{ '/private-sharing' | post_url }}">
-              Sharing Video Privately
-            </a>
-          </li>
-          <li>
-            <a href="{{ '/contacts' | post_url }}">
-              Contact Management
-            </a>
-          </li>
-          <li>
-            <a href="{{ '/permissions' | post_url }}">
-              Permission Types in Wistia
-            </a>
-          </li>
-          <li>
-            <a href="{{ '/alerts' | post_url }}">
-              Tracking Alerts
-            </a>
-          </li>
-        </ul>
       </div>
     </div>
     <div class='section'>
-      <div class='column left thirdRow' id='analytics'>
+      <div class='column left thirdRow' id='embedShare'>
         <h2>
-          <a href="{{ 'analytics' | category_url }}">Analytics</a>
+          <a href="{{ 'embed-and-share' | category_url }}">Embed & Share</a>
         </h2>
         <ul>
           <li>
-            <a href="{{ '/embedded-video-analytics' | post_url }}">
-              Analytics for Public Video
+            <a href="{{ '/embedding' | post_url }}">
+              Embedding
             </a>
           </li>
           <li>
-            <a href="{{ '/private-analytics' | post_url }}">
-              Analytics for Private Video
+            <a href="{{ '/video-seo' | post_url }}">
+              Video SEO
             </a>
           </li>
           <li>
-            <a href="{{ '/identity-tagging' | post_url }}">
-              Identity Tagging
+            <a href="{{ '/social-sharing' | post_url }}">
+              Social Sharing
+            </a>
+          </li>
+          <li>
+            <a href="{{ '/email-marketing' | post_url }}">
+              Email Marketing and Wistia
+            </a>
+          </li>
+          <li>
+            <a href="{{ '/playlists' | post_url }}">
+              Playlists
             </a>
           </li>
         </ul>
@@ -197,11 +202,6 @@ no_nav: true
             </a>
           </li>
           <li>
-            <a href="{{ '/pardot' | post_url }}">
-              Pardot
-            </a>
-          </li>
-          <li>
             <a href="{{ '/wordpress' | post_url }}">
               WordPress
             </a>
@@ -212,27 +212,35 @@ no_nav: true
             </a>
           </li>
         </ul>
+        <a class='viewAll' href="{{ 'integrations' | category_url }}">
+          View All 13
+        </a>
       </div>
-      <div class='column right thirdRow' id='publicSharing'>
+      <div class='column right thirdRow' id='stats'>
         <h2>
-          <a href="{{ 'public-sharing' | category_url }}">
-            Public Sharing
+          <a href="{{ 'stats' | category_url }}">
+            Stats
           </a>
         </h2>
         <ul>
           <li>
-            <a href="{{ '/email-marketing' | post_url }}">
-              Email Marketing
+            <a href="{{ '/embedded-video-analytics' | post_url }}">
+              Analytics Overview
             </a>
           </li>
           <li>
-            <a href="{{ '/video-seo' | post_url }}">
-              Video SEO
+            <a href="{{ '/audience-engagement-graph' | post_url }}">
+              Engagement Graphs
             </a>
           </li>
           <li>
-            <a href="{{ '/replaceable-video' | post_url }}">
-              Replaceable Video
+            <a href="{{ '/private-analytics' | post_url }}">
+              Private Analytics
+            </a>
+          </li>
+          <li>
+            <a href="{{ '/identity-tagging' | post_url }}">
+              Identity Tagging
             </a>
           </li>
         </ul>
@@ -302,7 +310,7 @@ no_nav: true
 <script type='text/javascript'>
   //<![CDATA[
     var iOS = ( navigator.userAgent.match(/(iPad|iPhone|iPod)/i) ? true : false );
-    
+
     if (!iOS) {
       $('.post_list li').each( function() {
         var $this = $(this),

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -503,7 +503,8 @@ h1, h2, h3, h4, .seo_faq { color: #363945; font-family: "Avenir", Futura, Helvet
 .home_container .section.last, .category_container .section.last { border-bottom: 0px solid #cbd0d6; }
 .home_container .column, .category_container .column { display: inline-block; *display: inline; vertical-align: top; zoom: 1; position: relative; }
 .home_container .column.developers, .category_container .column.developers { width: 50%; }
-.home_container .secondRow, .category_container .secondRow { height: 296px; margin-top: 6px; }
+.home_container .secondRow, .category_container .secondRow { height: 270px; margin-top: 6px; }
+.home_container .thirdRow, .category_container .thirdRow { height: 270px; margin-top: 6px; }
 .home_container .left, .category_container .left { width: 25%; padding-right: 9%; }
 .home_container .middle, .category_container .middle { width: 25%; padding-right: 9%; }
 .home_container .right, .category_container .right { width: 25%; padding-right: 5%; }


### PR DESCRIPTION
Rather than continuing to wonder if new categories will help organize the help pages, let's just do it. This pull requests revamps the "greatest hits" page as well as introduces 8 categories for all of the docs pages:
-Getting Started
-Account
-Customize
-Embed & Share
-Integrations
-Stats
-Troubleshooting (not on the index page)
-Dev

The dev category (being so huge and complicated) has not been touched. The initial commit for the new categories is here: https://github.com/wistia/wistia-doc/commit/a1389793abe4f0050c2e582bc06a634011db6a3f