### PR TITLE
Rack rewrite gem update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'nokogiri', '~> 1.5.5'
 gem 'rdiscount'
 gem 'sass', '~> 3.2'
 gem 'sinatra', '~> 1.3.3'
-gem 'rack-rewrite', '~> 1.5.0'
+gem 'rack-rewrite', '~> 1.5.1'
 gem 'unicorn'
 gem 'rake'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     rack (1.5.2)
     rack-protection (1.5.0)
       rack
-    rack-rewrite (1.5.0)
+    rack-rewrite (1.5.1)
     rack-test (0.6.2)
       rack (>= 1.0)
     raindrops (0.11.0)
@@ -114,7 +114,7 @@ DEPENDENCIES
   nokogiri (~> 1.5.5)
   pry (~> 0.9.12.6)
   psych (~> 2.0.6)
-  rack-rewrite (~> 1.5.0)
+  rack-rewrite (~> 1.5.1)
   rack-test (~> 0.6.2)
   rake
   rb-fsevent (~> 0.9.1)

--- a/the_app.rb
+++ b/the_app.rb
@@ -3,7 +3,7 @@
 #
 
 require 'pp'
-require 'rack/rewrite'
+require 'rack-rewrite'
 require 'elasticsearch'
 require_relative './_config'
 


### PR DESCRIPTION
Customer Jake reached out to me directly with an issue running the docs after updating to El Capitan.

![pastedgraphic-1](https://cloud.githubusercontent.com/assets/651753/10653060/e1c7f744-7829-11e5-8e2c-4525388941a3.png)

Based on the error, it _looks_ like the rack-rewrite gem could be at fault, but I can't reproduce.

This PR updates the rack-rewrite gem to the latest (1.5.0 -> 1.5.1), and also updates the call to that gem (`rack/rewrite` -> `rack-rewrite`). I don't have mega-confidence this will solve the issue, but stranger things have happened.

Has anyone else updated to El Cap, and then tried to run the docs locally?