### PR TITLE
Remove mention of the GA option in account settings and doc the embed…

### DIFF
--- a/_posts/embed-options.md
+++ b/_posts/embed-options.md
@@ -178,6 +178,15 @@ button will not appear.
 NOTE: On mobile devices where we use native controls, this option has no
 effect.
 
+### googleAnalytics
+
+If you're using Google Analytics on the page where you embed a video, the video
+will auto-magically send events to your Google Analytics account 📈.
+[Learn more about that here]({{ '/google-analytics' | post_url }}).
+
+If you _don't_ want a video to send those events to Google Analytics, set this
+embed option to `false`.
+
 ### playerPreference
 
 Possible values are "flash", "html5", and "auto". Default is "auto", which will

--- a/_posts/google-analytics.md
+++ b/_posts/google-analytics.md
@@ -33,7 +33,6 @@ __ga(function(){
 });
 {% endcodeblock %}
 
-You can disable our integration for all your videos by default by changing the configuration on the Account Settings page. You can also disable the integration for an individual video by modifying the initialization parameter for an API embed: `Wistia.embed("8cexf3sjf3", { "googleAnalytics": false });`.
 
 ## Google Tag Manager
 
@@ -59,4 +58,8 @@ Let's take a look at the data for the "play event" for this case. You'll see her
 
 {% post_image hashed_id: '1ef890a9af475643ea37b1bd048a7574ef589dee', width: 730, class: 'float_right' %}
 
-Using Wistia and Google Analytics is a good way to get all your top-level video analytics data in the same place you already get your other website tracking information. The screenshots above may not be _exactly_ like you see, since there are a few different versions of Google Analtics, Universal Analytics, etc.
+Using Wistia and Google Analytics is a good way to get all your top-level video analytics data in the same place you already get your other website tracking information. The screenshots above may not be _exactly_ like you see, since there are a few different versions of Google Analytics, Universal Analytics, etc.
+
+## Disable Google Analytics Tracking
+
+Want to prevent a video from generating events in your Google Analytics account? There's an [Embed Option]({{ '/embed-options#googleAnalytics' | post_url }}) for that. Set `googleAnalytics` to `false`, and your video will go about its business without bothering Google Analytics. It will continue to generate stats in your Wistia account as usual.

--- a/_posts/google-analytics.md
+++ b/_posts/google-analytics.md
@@ -62,4 +62,4 @@ Using Wistia and Google Analytics is a good way to get all your top-level video 
 
 ## Disable Google Analytics Tracking
 
-Want to prevent a video from generating events in your Google Analytics account? There's an [Embed Option]({{ '/embed-options#googleAnalytics' | post_url }}) for that. Set `googleAnalytics` to `false`, and your video will go about its business without bothering Google Analytics. It will continue to generate stats in your Wistia account as usual.
+Want to prevent a video from generating events in your Google Analytics account? There's an [Embed Option]({{ '/embed-options#googleanalytics' | post_url }}) for that. Set `googleAnalytics` to `false`, and your video will go about its business without bothering Google Analytics. It will continue to generate stats in your Wistia account as usual.


### PR DESCRIPTION
… option


The Google Analytics option in https://my.wistia.com/account/profile doesn't actually do anything, and is scheduled to be removed shortly. This PR removes documentation about that setting, and adds more documentation about the `googleAnalytics` embed option.

@emilyscoleman, :eyes: please!