### PR TITLE
Help Center beta

### DIFF
--- a/_includes/doc_nav.html
+++ b/_includes/doc_nav.html
@@ -41,7 +41,7 @@
         </li>
         {% endif %}
         <li class='doc_nav_search' id='search'>
-          <input class='st-default-search-input' id='searchField' placeholder='Search our docs' type='text' />
+          <input class='st-default-search-input' id='searchField' placeholder='Search our Help Pages' type='text' />
         </li>
       </ul>
     </div>

--- a/_includes/doc_nav.html
+++ b/_includes/doc_nav.html
@@ -4,7 +4,7 @@
       <ul>
         {% if page.type != 'post' %}
         <li id='breadcrumbs'>
-          <a href="{{ '/' | post_url }}" style='padding-left: 0;'>Documentation</a>
+          <a href='http://wistia.com/support' style='padding-left: 0;'>Help Center</a>
           <span class='breadcrumb_post_title'>
             <img src="{{ '/images/greaterThan.png' | image_url }}" />
             {% if page.type %}
@@ -17,7 +17,7 @@
         {% else %}
         <li id='breadcrumbs'>
           {% if page.category && page.category != 'no_index' %}
-          <a href="{{ '/' | post_url }}">Documentation</a>
+          <a href='http://wistia.com/support'>Help Center</a>
           <span class='breadcrumb_post_title'>
             <img src="{{ '/images/greaterThan.png' | image_url }}" />
             {% if page.special_category_link %}
@@ -32,7 +32,7 @@
             {% endif %}
           </span>
           {% else %}
-          <a href="{{ '/' | post_url }}">Documentation</a>
+          <a href='http://wistia.com/support'>Help Center</a>
           {% endif %}
           <span class='breadcrumb_post_title'>
             <img src="{{ '/images/greaterThan.png' | image_url }}" />

--- a/_includes/haml/doc_nav.haml
+++ b/_includes/haml/doc_nav.haml
@@ -40,4 +40,4 @@
 
         {% endif %}
         %li#search.doc_nav_search
-          %input#searchField.st-default-search-input{ type: "text", placeholder: "Search our docs" }
+          %input#searchField.st-default-search-input{ type: "text", placeholder: "Search our Help Pages" }

--- a/_includes/haml/doc_nav.haml
+++ b/_includes/haml/doc_nav.haml
@@ -4,7 +4,7 @@
       %ul
         {% if page.type != 'post' %}
         %li#breadcrumbs
-          %a{ style: 'padding-left: 0;', href: "{{ '/' | post_url }}" } Documentation
+          %a{ style: 'padding-left: 0;', href: 'http://wistia.com/support' } Help Center
           %span.breadcrumb_post_title
             %img{ src: "{{ '/images/greaterThan.png' | image_url }}" }
             {% if page.type %}
@@ -17,7 +17,7 @@
         %li#breadcrumbs
 
           {% if page.category && page.category != 'no_index' %}
-          %a{ href: "{{ '/' | post_url }}" } Documentation
+          %a{ href: 'http://wistia.com/support' } Help Center
           %span.breadcrumb_post_title
             %img{ src: "{{ '/images/greaterThan.png' | image_url }}" }
             {% if page.special_category_link %}
@@ -32,7 +32,7 @@
             {% endif %}
 
           {% else %}
-          %a{ href: "{{ '/' | post_url }}" } Documentation
+          %a{ href: 'http://wistia.com/support' } Help Center
           {% endif %}
           %span.breadcrumb_post_title
             %img{ src: "{{ '/images/greaterThan.png' | image_url }}" }


### PR DESCRIPTION
Update the top navigation in the Help Pages to point back to http://wistia.com/support, rather than doc index.

This also updates the placeholder text in the search boxes on individual Help Pages.

<img width="1001" alt="screenshot 2015-11-13 17 57 21" src="https://cloud.githubusercontent.com/assets/651753/11159671/02e934d4-8a30-11e5-9519-f5184b7fcefa.png">

@emilyscoleman merge at your convenience :sandal: 