### PR TITLE
Change font-weight from 200 to normal

### DIFF
--- a/_sass/_post_content.sass
+++ b/_sass/_post_content.sass
@@ -81,7 +81,6 @@
     line-height: 2em
     position: relative
     font-size: 17px
-    font-weight: 200
     font-family: $fonts
     color: $gray6
     margin-top: 10px

--- a/_sass/_post_content.sass
+++ b/_sass/_post_content.sass
@@ -81,6 +81,7 @@
     line-height: 2em
     position: relative
     font-size: 17px
+    font-weight: 400
     font-family: $fonts
     color: $gray6
     margin-top: 10px

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -540,7 +540,7 @@ h1, h2, h3, h4, .seo_faq { color: #363945; font-family: "Whitney A", "Whitney B"
 .post_content ul a:hover { border-bottom: 1px solid #3ea9f5; text-decoration: none; }
 .post_content ol { line-height: 150%; list-style: decimal; }
 .post_content ol li { margin-left: 30px; }
-.post_content p { margin-left: 0px; line-height: 2em; position: relative; font-size: 17px; font-weight: 200; font-family: "Whitney A", "Whitney B", "Avenir", Helvetica, sans-serif; color: #161d25; margin-top: 10px; margin-bottom: 18px; word-wrap: break-word; }
+.post_content p { margin-left: 0px; line-height: 2em; position: relative; font-size: 17px; font-family: "Whitney A", "Whitney B", "Avenir", Helvetica, sans-serif; color: #161d25; margin-top: 10px; margin-bottom: 18px; word-wrap: break-word; }
 .post_content p a { text-decoration: none !important; }
 .post_content p pre { margin: 0px 0 0px 0px; background-color: #eceef1; }
 

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -540,7 +540,7 @@ h1, h2, h3, h4, .seo_faq { color: #363945; font-family: "Whitney A", "Whitney B"
 .post_content ul a:hover { border-bottom: 1px solid #3ea9f5; text-decoration: none; }
 .post_content ol { line-height: 150%; list-style: decimal; }
 .post_content ol li { margin-left: 30px; }
-.post_content p { margin-left: 0px; line-height: 2em; position: relative; font-size: 17px; font-family: "Whitney A", "Whitney B", "Avenir", Helvetica, sans-serif; color: #161d25; margin-top: 10px; margin-bottom: 18px; word-wrap: break-word; }
+.post_content p { margin-left: 0px; line-height: 2em; position: relative; font-size: 17px; font-weight: 400; font-family: "Whitney A", "Whitney B", "Avenir", Helvetica, sans-serif; color: #161d25; margin-top: 10px; margin-bottom: 18px; word-wrap: break-word; }
 .post_content p a { text-decoration: none !important; }
 .post_content p pre { margin: 0px 0 0px 0px; background-color: #eceef1; }
 


### PR DESCRIPTION
I was just reading a page in the Help Center and noticed that it felt like the font was really thin. Upon further inspection, I found that we're setting `font-weight` to 200. Keeping `font-weight` normal is more readable in my opinion.

Here's what it looks like now:

![image](https://s3.amazonaws.com/f.cl.ly/items/0p2A2R441g0z0e0U1t2e/Image%202015-12-08%20at%209.33.42%20PM.png?v=af6ed856)

And here's what it would look like with this change:
![image](https://s3.amazonaws.com/f.cl.ly/items/21063P2J1F2C2g1P2K0o/Image%202015-12-08%20at%209.32.30%20PM.png?v=6429afb0)

@emilyscoleman @liatwerber, would you agree? If so, this change look OK?

If not, please disregard this PR. No hard feelings.