### PR TITLE
Pretty up the bandwidth pricing guidance table

### DIFF
--- a/_posts/bandwidth.md
+++ b/_posts/bandwidth.md
@@ -174,9 +174,9 @@ Bandwidth Option| Monthly Cost | Extra Bandwidth Pricing | When It Makes Cents �
 -----|----------------|---------|------------
 200GB | Free | 0.33¢/GB | 807 GB in total bandwidth ($200.31)
 1 TB | $200 | 0.18¢/GB | 4,080 GB in total bandwidth ($750.08)
-5 TB | $ 750 | 0.15¢/GB | 10,120 GB in total bandwidth ($1,500)
-15 TB | $1500 | 0.10¢/GB | 30,360 GB in total bandwidth ($3,000)
-50 TB | $3000 | 0.06¢/GB | [Contact us](http://wistia.com/support/contact)
+5 TB | $750 | 0.15¢/GB | 10,120 GB in total bandwidth ($1,500)
+15 TB | $1,500 | 0.10¢/GB | 30,360 GB in total bandwidth ($3,000)
+50 TB | $3,000 | 0.06¢/GB | [Contact us](http://wistia.com/support/contact)
 
 Still not sure? [Talk to us.](http://wistia.com/support/contact) We weren't all
 Calculus majors, but we can figure our way around a calculator. We'd love to

--- a/_sass/_post_content.sass
+++ b/_sass/_post_content.sass
@@ -320,6 +320,8 @@ table
     a
       color: $blue
       text-decoration: underline
+    &:nth-child(4)
+      width: 42%
   tr
     &:hover
       td

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -621,6 +621,7 @@ table { font-size: 15px; line-height: 140%; font-family: "Whitney A", "Whitney B
 table th { font-size: 15px; padding: 10px 20px; background: #3ea9f5; border-bottom: 2px solid white; color: white; }
 table td { padding: 5px 20px; background: rgba(62, 169, 245, 0.2); border-bottom: 1px solid white; color: #3ea9f5; border-top: 1px solid transparent; word-wrap: break-word; }
 table td a { color: #0e7ac4; text-decoration: underline; }
+table td:nth-child(4) { width: 42%; }
 table tr:hover td { background: rgba(62, 169, 245, 0.1); color: #3ea9f5; }
 table tr td pre { margin: 0; padding: 0; }
 


### PR DESCRIPTION
I left this way too messy earlier! Here's a quick cleanup. Taking it from this:

![image](https://cloud.githubusercontent.com/assets/752729/11735675/1a55307e-9f92-11e5-9e92-56a45322a0a1.png)

to this:

![image](https://cloud.githubusercontent.com/assets/752729/11735681/28058ba6-9f92-11e5-950a-400bac355480.png)


@emilyscoleman :+1: / :-1: ?