### PR TITLE
JH fix for the socialbar plugin brackets

### DIFF
--- a/_posts/embed-options.md
+++ b/_posts/embed-options.md
@@ -511,6 +511,7 @@ _wq.push({ "4d8": {
       buttons: "embed-twitter-facebook"
     }
   }
+}
 });
 </script>
 <script charset="ISO-8859-1" src="//fast.wistia.com/assets/external/E-v1.js" async></script>
@@ -531,6 +532,7 @@ _wq.push({ "4d8": {
       pageTitle: "Wistia's Blog"
     }
   }
+}
 });
 </script>
 <script charset="ISO-8859-1" src="//fast.wistia.com/assets/external/E-v1.js" async></script>


### PR DESCRIPTION
I added another bracket to the code for the Socialbar plugin examples. They were missing one, which made them not work and frustrating to copy and paste when trying to use the Socialbar plugin. I didn't want to forget about it because it's minor, @emilyscoleman 